### PR TITLE
[FEAT] 메모리 편집 락 기능 추가 및 전역 모달/스낵바 UI 버그 수정

### DIFF
--- a/api/memory.ts
+++ b/api/memory.ts
@@ -73,6 +73,7 @@ export interface PutMemoryPayload {
     endDate: string;
     memoryItems: MemoryItem[];
     accesses: AccessInfo[];
+    editLockToken: string;
 }
 export interface MemoryItem {
     imageUrl: string;
@@ -104,6 +105,18 @@ export interface GetMemoriesPayload {
 }
 
 export interface GetMemoriesResponse extends SearchMemoryResponse {}
+
+export interface EditLockResponse {
+    acquired: boolean;
+    token?: string;
+    ttl?: number;
+    holderId?: number;
+    holderNickname?: string;
+}
+
+export interface EditLockHeartbeatResponse {
+    ttl: number;
+}
 
 const putMemory = async (memoryId: number, memory: PutMemoryPayload) => {
     const response = await apiClient
@@ -167,11 +180,13 @@ const getMemories = async (payload: GetMemoriesPayload) => {
 };
 
 const getMemory = async (memoryId: number) => {
+    console.log("getMemory", memoryId);
     const response = await apiClient
         .get(`memories/${memoryId}`, {
             withAuth: true,
         })
         .catch((error) => {
+            console.log("getMemory error", error);
             console.log(error);
         });
 
@@ -267,6 +282,75 @@ const searchMemories = async (payload: SearchMemoryPayload) => {
     return response.data as SearchMemoryResponse;
 };
 
+const acquireEditLock = async (memoryId: number) => {
+    const response = await apiClient
+        .post(
+            `memories/${memoryId}/edit-session`,
+            {},
+            {
+                withAuth: true,
+            }
+        )
+        .catch((error) => {
+            console.log(error);
+        });
+
+    if (!response) {
+        throw new Error("편집 락 획득에 실패했습니다.");
+    }
+
+    if (response.status !== 200) {
+        throw new Error("편집 락 획득에 실패했습니다.");
+    }
+
+    return response.data as EditLockResponse;
+};
+
+const releaseEditLock = async (memoryId: number, token: string) => {
+    const response = await apiClient
+        .delete(`memories/${memoryId}/edit-session`, {
+            data: { token },
+            withAuth: true,
+        })
+        .catch((error) => {
+            console.log(error);
+        });
+
+    if (!response) {
+        throw new Error("편집 락 해제에 실패했습니다.");
+    }
+
+    if (response.status !== 200) {
+        throw new Error("편집 락 해제에 실패했습니다.");
+    }
+
+    return true;
+};
+
+const extendEditLock = async (memoryId: number, token: string) => {
+    const response = await apiClient
+        .post(
+            `memories/${memoryId}/edit-session/heartbeat`,
+            { token },
+            {
+                withAuth: true,
+            }
+        )
+        .catch((error) => {
+            console.log(error);
+        });
+
+    if (!response) {
+        throw new Error("편집 락 연장에 실패했습니다.");
+    }
+
+    if (response.status !== 200) {
+        throw new Error("편집 락 연장에 실패했습니다.");
+    }
+
+    return response.data as EditLockHeartbeatResponse;
+};
+
 export {
     putMemory,
     deleteMemory,
@@ -276,4 +360,7 @@ export {
     getMemoryTempItems,
     getMemory,
     searchMemories,
+    acquireEditLock,
+    releaseEditLock,
+    extendEditLock,
 };

--- a/api/memory.ts
+++ b/api/memory.ts
@@ -180,13 +180,11 @@ const getMemories = async (payload: GetMemoriesPayload) => {
 };
 
 const getMemory = async (memoryId: number) => {
-    console.log("getMemory", memoryId);
     const response = await apiClient
         .get(`memories/${memoryId}`, {
             withAuth: true,
         })
         .catch((error) => {
-            console.log("getMemory error", error);
             console.log(error);
         });
 
@@ -320,11 +318,9 @@ const releaseEditLock = async (memoryId: number, token: string) => {
         throw new Error("편집 락 해제에 실패했습니다.");
     }
 
-    if (response.status !== 200) {
+    if (response.status !== 204 && response.status !== 200) {
         throw new Error("편집 락 해제에 실패했습니다.");
     }
-
-    return true;
 };
 
 const extendEditLock = async (memoryId: number, token: string) => {
@@ -347,6 +343,8 @@ const extendEditLock = async (memoryId: number, token: string) => {
     if (response.status !== 200) {
         throw new Error("편집 락 연장에 실패했습니다.");
     }
+
+    console.log("extendEditLock", response.data);
 
     return response.data as EditLockHeartbeatResponse;
 };

--- a/api/memory.ts
+++ b/api/memory.ts
@@ -344,8 +344,6 @@ const extendEditLock = async (memoryId: number, token: string) => {
         throw new Error("편집 락 연장에 실패했습니다.");
     }
 
-    console.log("extendEditLock", response.data);
-
     return response.data as EditLockHeartbeatResponse;
 };
 

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -8,7 +8,7 @@ import DetailLog from "@/components/logs/DetailLog";
 import LogItem from "@/components/logs/LogItem";
 import { Colors } from "@/constants/Colors";
 import { formatDate } from "@/utils/formatDate";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import {
     Dimensions,
@@ -39,6 +39,7 @@ export default function CalendarScreen() {
                 yearMonth: selectedMonth as `${number}-${number}`,
                 category: selectedCategory ?? undefined,
             }),
+        placeholderData: keepPreviousData,
     });
 
     const handleDayPress = (day: string) => {

--- a/components/logs/LogEdit.tsx
+++ b/components/logs/LogEdit.tsx
@@ -1,11 +1,17 @@
-import { Memory, putMemory } from "@/api/memory";
+import {
+    Memory,
+    acquireEditLock,
+    extendEditLock,
+    putMemory,
+    releaseEditLock,
+} from "@/api/memory";
 import PageLayout from "@/components/common/PageLayout";
 import { ThemedText } from "@/components/common/ThemedText";
 import LogCard from "@/components/edit/LogCard";
 import { Colors } from "@/constants/Colors";
 import { useUI } from "@/hooks/useUI";
-import { useNavigation, useRouter } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useNavigation } from "expo-router";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
     BackHandler,
     StyleSheet,
@@ -28,9 +34,64 @@ export default function LogEdit({
     const { showModal } = useUI();
     const navigation = useNavigation();
     const [dirty, setDirty] = useState(false);
+    const [lockToken, setLockToken] = useState<string | null>(null);
     const markDirty = useCallback(() => setDirty(true), []);
+    const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const lockTokenRef = useRef<string | null>(null);
+
+    const clearHeartbeat = useCallback(() => {
+        if (heartbeatRef.current) {
+            clearInterval(heartbeatRef.current);
+            heartbeatRef.current = null;
+        }
+    }, []);
+
+    const cleanupLock = useCallback(async () => {
+        clearHeartbeat();
+        const token = lockTokenRef.current;
+        if (!token) return;
+        lockTokenRef.current = null;
+        try {
+            await releaseEditLock(memory.id, token);
+        } catch (error) {
+            console.log("편집 락 해제 실패", error);
+        }
+    }, [memory.id, clearHeartbeat]);
+
+    const performExit = useCallback(() => {
+        setDirty(false);
+        cleanupLock()
+            .catch(() => {})
+            .finally(() => {
+                onBack();
+            });
+    }, [cleanupLock, onBack]);
+
+    const requestExit = useCallback(() => {
+        if (!dirty) {
+            performExit();
+            return;
+        }
+        showModal({
+            title: "정말 취소하시겠습니까?",
+            subtitle: "진행 중인 작업이 모두 취소됩니다.",
+            confirmText: "취소",
+            cancelText: "돌아가기",
+            onConfirm: () => {
+                performExit();
+            },
+        });
+    }, [dirty, showModal, performExit]);
 
     const handleSave = useCallback(() => {
+        if (!lockTokenRef.current) {
+            showModal({
+                title: "편집 준비 중입니다.",
+                subtitle: "잠시 후 다시 시도해주세요.",
+                confirmText: "확인",
+            });
+            return;
+        }
         putMemory(memory.id, {
             title: memory.title,
             category: memory.category,
@@ -41,10 +102,19 @@ export default function LogEdit({
                 userId: access.userId,
                 permissionLevel: access.permissionLevel,
             })),
-        }).finally(() => {
-            onBack();
-        });
-    }, [memory]);
+            editLockToken: lockTokenRef.current,
+        })
+            .then(() => {
+                performExit();
+            })
+            .catch(() => {
+                showModal({
+                    title: "저장에 실패했습니다.",
+                    subtitle: "잠시 후 다시 시도해주세요.",
+                    confirmText: "확인",
+                });
+            });
+    }, [memory, performExit, showModal]);
 
     // memory 변경 시 dirty 체크
     useEffect(() => {
@@ -58,43 +128,35 @@ export default function LogEdit({
         const beforeRemove = navigation.addListener(
             "beforeRemove",
             (e: any) => {
-                if (!dirty) return; // 변경 없으면 그냥 나감
-
-                e.preventDefault(); // 이탈 막기 → 모달 띄우기
-
+                if (!dirty) return;
+                e.preventDefault();
                 showModal({
                     title: "정말 취소하시겠습니까?",
                     subtitle: "진행 중인 작업이 모두 취소됩니다.",
                     confirmText: "취소",
                     cancelText: "돌아가기",
                     onConfirm: () => {
-                        // 확인(=정말 나가기) 시: 리스너 임시 해제 후 원래 액션 수행
-                        const sub = navigation.addListener(
-                            "beforeRemove",
-                            () => {}
-                        );
-                        sub(); // 즉시 해제
-                        setDirty(false);
-                        onBack();
+                        performExit();
                     },
                 });
             }
         );
 
-        // Android 하드웨어 백 안전망(대부분 beforeRemove로 커버됨)
         const onHardwareBack = () => {
-            if (!dirty) return false; // 기본 동작(뒤로가기)
+            if (!dirty) {
+                performExit();
+                return true;
+            }
             showModal({
                 title: "정말 취소하시겠습니까?",
                 subtitle: "진행 중인 작업이 모두 취소됩니다.",
                 confirmText: "취소",
                 cancelText: "돌아가기",
                 onConfirm: () => {
-                    setDirty(false);
-                    onBack();
+                    performExit();
                 },
             });
-            return true; // 우리가 처리했음
+            return true;
         };
         const backSub = BackHandler.addEventListener(
             "hardwareBackPress",
@@ -105,7 +167,73 @@ export default function LogEdit({
             beforeRemove();
             backSub.remove();
         };
-    }, [dirty, navigation, showModal, onBack]);
+    }, [dirty, navigation, showModal, performExit]);
+
+    useEffect(() => {
+        let mounted = true;
+        const acquireLock = async () => {
+            try {
+                const lock = await acquireEditLock(memory.id);
+                if (!lock?.acquired || !lock.token) {
+                    throw new Error("편집 락을 획득하지 못했습니다.");
+                }
+                if (mounted) {
+                    setLockToken(lock.token);
+                }
+            } catch (error) {
+                if (!mounted) return;
+                showModal({
+                    title: "편집할 수 없습니다.",
+                    subtitle: "다른 사용자가 이 기록을 편집 중입니다.",
+                    confirmText: "확인",
+                    onConfirm: () => {
+                        performExit();
+                    },
+                });
+            }
+        };
+        acquireLock();
+
+        return () => {
+            mounted = false;
+        };
+    }, [memory.id, showModal, performExit]);
+
+    useEffect(() => {
+        lockTokenRef.current = lockToken;
+    }, [lockToken]);
+
+    useEffect(() => {
+        if (!lockToken) return;
+
+        clearHeartbeat();
+        heartbeatRef.current = setInterval(async () => {
+            if (!lockTokenRef.current) return;
+            try {
+                await extendEditLock(memory.id, lockTokenRef.current);
+            } catch (error) {
+                clearHeartbeat();
+                showModal({
+                    title: "편집 세션이 만료되었습니다.",
+                    subtitle: "다시 시도해주세요.",
+                    confirmText: "확인",
+                    onConfirm: () => {
+                        performExit();
+                    },
+                });
+            }
+        }, 120000);
+
+        return () => {
+            clearHeartbeat();
+        };
+    }, [lockToken, memory.id, showModal, clearHeartbeat, performExit]);
+
+    useEffect(() => {
+        return () => {
+            cleanupLock();
+        };
+    }, [cleanupLock]);
 
     return (
         <PageLayout
@@ -113,7 +241,7 @@ export default function LogEdit({
             hasBack
             backText="취소"
             scrollView
-            onBack={onBack}
+            onBack={requestExit}
             headerRight={
                 <TouchableOpacity onPress={handleSave}>
                     <ThemedText

--- a/components/logs/LogEdit.tsx
+++ b/components/logs/LogEdit.tsx
@@ -200,6 +200,9 @@ export default function LogEdit({
                     onConfirm: () => {
                         performExit();
                     },
+                    onCancel: () => {
+                        performExit();
+                    },
                 });
             }
         };
@@ -229,6 +232,9 @@ export default function LogEdit({
                     subtitle: "다시 시도해주세요.",
                     confirmText: "확인",
                     onConfirm: () => {
+                        performExit();
+                    },
+                    onCancel: () => {
                         performExit();
                     },
                 });

--- a/components/logs/LogEdit.tsx
+++ b/components/logs/LogEdit.tsx
@@ -38,6 +38,7 @@ export default function LogEdit({
     const markDirty = useCallback(() => setDirty(true), []);
     const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const lockTokenRef = useRef<string | null>(null);
+    const savedRef = useRef(false);
 
     const clearHeartbeat = useCallback(() => {
         if (heartbeatRef.current) {
@@ -66,6 +67,16 @@ export default function LogEdit({
                 onBack();
             });
     }, [cleanupLock, onBack]);
+
+    const performExitWithoutRelease = useCallback(() => {
+        // 기록 수정이 성공한 경우에는 서버에서 편집 락을 정리하므로
+        // 클라이언트에서는 편집 락 해제 API를 호출하지 않는다.
+        setDirty(false);
+        savedRef.current = true;
+        clearHeartbeat();
+        lockTokenRef.current = null;
+        onBack();
+    }, [clearHeartbeat, onBack]);
 
     const requestExit = useCallback(() => {
         if (!dirty) {
@@ -105,7 +116,7 @@ export default function LogEdit({
             editLockToken: lockTokenRef.current,
         })
             .then(() => {
-                performExit();
+                performExitWithoutRelease();
             })
             .catch(() => {
                 showModal({
@@ -114,7 +125,7 @@ export default function LogEdit({
                     confirmText: "확인",
                 });
             });
-    }, [memory, performExit, showModal]);
+    }, [memory, performExitWithoutRelease, showModal]);
 
     // memory 변경 시 dirty 체크
     useEffect(() => {
@@ -231,9 +242,15 @@ export default function LogEdit({
 
     useEffect(() => {
         return () => {
-            cleanupLock();
+            // 저장에 성공한 경우에는 편집 락 해제 API를 별도로 호출하지 않는다.
+            if (!savedRef.current) {
+                cleanupLock();
+            } else {
+                clearHeartbeat();
+                lockTokenRef.current = null;
+            }
         };
-    }, [cleanupLock]);
+    }, [cleanupLock, clearHeartbeat]);
 
     return (
         <PageLayout

--- a/contexts/UIContext.tsx
+++ b/contexts/UIContext.tsx
@@ -38,15 +38,19 @@ export const UIProvider = ({ children }: { children: React.ReactNode }) => {
     });
 
     const showModal = useCallback((options: Omit<ModalOptions, "visible">) => {
+        // 항상 새 옵션으로 덮어써서 이전 모달 내용이 남지 않도록 처리
         setModal({ visible: true, ...options });
     }, []);
 
     const hideModal = useCallback(() => {
-        setModal((prev) => ({ ...prev, visible: false }));
+        // 모달을 닫을 때는 내용도 함께 초기화하여
+        // 다음 모달이 열릴 때 이전 내용이 잠깐 보이지 않도록 한다.
+        setModal({ visible: false });
     }, []);
 
     const showSnackbar = useCallback(
         (options: Omit<SnackbarOptions, "visible">) => {
+            // 항상 새 옵션으로 덮어써서 이전 스낵바 내용이 남지 않도록 처리
             setSnackbar({ visible: true, ...options });
 
             setTimeout(() => {
@@ -57,7 +61,9 @@ export const UIProvider = ({ children }: { children: React.ReactNode }) => {
     );
 
     const hideSnackbar = useCallback(() => {
-        setSnackbar((prev) => ({ ...prev, visible: false }));
+        // 스낵바를 닫을 때 메시지를 초기화하여
+        // 다음 스낵바가 열릴 때 이전 메시지가 잠깐 보이지 않도록 한다.
+        setSnackbar({ visible: false, message: "" });
     }, []);
 
     return (


### PR DESCRIPTION
### 📌 Pull request
<!-- PR 주제를 작성 ex) feat: 회원가입 폼 UI 구현 -->
> 메모리 편집 락 기능 추가 및 전역 모달/스낵바 UI 버그 수정

---

### ✨ 작업 개요
<!-- 어떤 기능을 개발/수정했는지 간략히 작성 -->
- 메모리 편집 시 동시 편집을 방지하기 위한 편집 락 기능 추가
- 전역 모달/스낵바에서 이전 내용이 잠깐 보이는 깜빡임 이슈 수정

---

### 🔧 변경 사항
<!-- 주요 변경 사항을 작성 -->
**메모리 편집 락 기능 추가 (LogEdit)**
- 편집 진입 시 acquireEditLock을 통해 편집 락 토큰을 획득하고, 주기적으로 extendEditLock을 호출해 세션을 연장
- 다른 사용자가 이미 편집 중인 경우, 편집 불가 안내 모달을 띄우고 화면에서 빠져나오도록 처리
- 기록 저장 요청 시 서버에 editLockToken를 함께 전달하여 락 보유자만 수정 가능하도록 함
- 저장 성공 시에는 서버에서 락 정리를 담당하도록 하고, 클라이언트에서는 별도의 releaseEditLock 호출 없이 화면만 종료
취소/뒤로가기/세션 만료 등 비정상 종료 경로에서는 cleanupLock을 통해 편집 락을 명시적으로 해제


**전역 모달/스낵바 깜빡임 이슈 수정 (UIContext)**
- hideModal 시 모달 상태를 { visible: false }로 초기화하여, 다음 모달 표시 때 이전 제목/부제/버튼 텍스트가 잠깐 보이지 않도록 개선
- hideSnackbar 시 { visible: false, message: "" }로 메시지를 초기화하여, 연속 노출 시 이전 메시지가 섞여 보이지 않도록 수정
- showModal, showSnackbar에서 항상 새 옵션으로 상태를 덮어써, 이전 옵션이 남아 있는 경우를 방지

---

### 📸 스크린샷
<!-- UI 변경이 있다면 before / after 이미지 첨부 -->
- 해당 없음
---

### 📂 관련 이슈
<!-- 해당할 경우에만 작성 -->
- 해당 없음

---

### 📌 기타 참고 사항
<!-- 리뷰어가 알면 좋을 정보 (ex. npm install 필요, API Key 필요 등) -->
- 해당 없음
